### PR TITLE
Add AWS WAF with rate-based rules for REL05-BP02 compliance

### DIFF
--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/README.md
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/README.md
@@ -8,14 +8,20 @@ Creates an [AWS Lambda](https://aws.amazon.com/lambda/) function writing to [Ama
 
 ![architecture](docs/architecture.png)
 
-## Throttling Configuration
+## Security and Throttling Configuration
 
-This stack implements AWS Well-Architected Framework best practice **REL05-BP02: Throttle requests** to protect against resource exhaustion:
+This stack implements AWS Well-Architected Framework best practice **REL05-BP02: Throttle requests** with multiple layers of protection:
 
+### API Gateway Throttling
 - **Rate Limit**: 100 requests per second
 - **Burst Limit**: 200 requests
 
-These limits protect the API from unexpected traffic spikes and ensure consistent performance. If you need higher limits, conduct load testing to validate your infrastructure can handle the increased load before adjusting these values.
+### AWS WAF Rate-Based Protection
+- **IP Rate Limit**: 2,000 requests per 5 minutes per IP address
+- **AWS Managed Rules**: Common Rule Set for additional security
+- **CloudWatch Metrics**: Enabled for monitoring blocked requests
+
+These limits protect the API from unexpected traffic spikes, DDoS attacks, and ensure consistent performance. If you need higher limits, conduct load testing to validate your infrastructure can handle the increased load before adjusting these values.
 
 ## Setup
 


### PR DESCRIPTION
## Summary

This PR implements AWS WAF with rate-based rules addressing AWS Well-Architected Framework best practice **REL05-BP02: Throttle requests**. The changes add IP-level protection against flooding attacks and DDoS attempts.

Fixes #7

## Changes Made

### AWS WAF Web ACL Configuration
- Created WAF Web ACL with rate-based rule limiting 2,000 requests per 5 minutes per IP
- Added AWS Managed Rules Common Rule Set for additional security
- Enabled CloudWatch metrics for monitoring

### WAF Association
- Associated WAF Web ACL with API Gateway stage
- Imported `aws_wafv2` module for WAF resources

### Documentation Updates
- Added WAF rate-based protection section to README
- Documented IP rate limits and managed rules

## Well-Architected Framework Compliance

These changes mitigate high-risk exposure by adding IP-level rate limiting to protect against flooding attacks, DDoS attempts, and malicious actors. This provides an additional layer of protection beyond API Gateway throttling.

✅ **DDoS Protection**: Blocks IPs exceeding rate limits to prevent flooding attacks
✅ **Malicious Actor Mitigation**: Rate limits per IP prevent single actors from exhausting resources
✅ **Enhanced Security**: AWS Managed Rules provide protection against common threats
✅ **Observability**: CloudWatch metrics enable monitoring of blocked requests

## Testing

After deployment:
1. Monitor CloudWatch metrics for `ApiWebAcl` and `RateLimitRule`
2. Review WAF sampled requests in AWS WAF console
3. Test rate limiting by exceeding 2,000 requests per 5 minutes from a single IP
4. Verify blocked requests receive appropriate responses

## Files Modified

- `python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py` - Added WAF Web ACL with rate-based rules and association
- `python/apigw-http-api-lambda-dynamodb-python-cdk/README.md` - Documented WAF protection configuration